### PR TITLE
fill sourceFeedLink so it can be used in the deposit comment

### DIFF
--- a/eschol/logic.py
+++ b/eschol/logic.py
@@ -136,6 +136,7 @@ def get_article_json(article, unit):
     item = {
         "sourceName": sourceName,
         "sourceID": str(article.pk),
+        "sourceFeedLink": article.journal.press.domain,
         "submitterEmail": article.owner.email,
         "title": article.title,
         "type": "ARTICLE",
@@ -363,6 +364,7 @@ def register_doi(article, epub):
             epub.save()
         else:
             success, result_text = update_journal_doi(article=article)
+            logger.info(result_text)
             epub.doi_result_text = result_text
             epub.save()
     except ImportError or ModuleNotFoundError:


### PR DESCRIPTION
just use the press domain now because everything is is path mode if we have sites in domain mode it would have to check for that.

There is also some extra logging in here.  Not related but doesn't hurt to have it.