### PR TITLE
remove unused declarations

### DIFF
--- a/templates/eschol/escholarship.html
+++ b/templates/eschol/escholarship.html
@@ -1,6 +1,3 @@
-{% load static from staticfiles %}
-{% load hooks %}
-{% load i18n %}
 <html>
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
Not sure why I ever included these.  they aren't used and new version of django doesn't like them.