### PR TITLE
improve ark and doi imports

### DIFF
--- a/management/commands/add_arks.py
+++ b/management/commands/add_arks.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 import json, csv
 
@@ -28,17 +28,47 @@ class Command(BaseCommand):
         journal_code = options.get("journal_code")
         import_file = options.get("import_file")
 
+        if not Journal.objects.filter(code=journal_code).exists():
+            raise CommandError(f'Journal does not exist {journal_code}')
+
         j = Journal.objects.get(code=journal_code)
 
+        # map ojs_id to ark, source and doi
         id_map = {}
+        # map arks to source and doi
+        # (just in case we have no ojs id but we have an ark in a log entry)
+        ark_map = {}
         with open(import_file, 'r') as csvfile:
             reader = csv.DictReader(csvfile, delimiter="\t")
             for r in reader:
-                id_map[r["external_id"]] = {"ark": r["id"], "source": r["source"], "doi": r["doi"]}
+                ojs_id = None
+                # if source is ojs 'external_id' should match
+                # source_id in janeway log entry
+                if r["source"] == "ojs":
+                    ojs_id = r["external_id"]
+                    print(f'use external_id as ojs_id {ojs_id}')
+                # if the original source is not ojs we may still have a local_id
+                # that includes the ojs id
+                elif "local_ids" in r and r["local_ids"] and not r["local_ids"]  == "NULL":
+                    local_ids = json.loads(r["local_ids"])
+                    for x in local_ids:
+                        # unfortunately the local id that contains
+                        # the ojs id has type 'None' so see if it
+                        # matches the pattern
+                        prefix = f'{journal_code}_'
+                        if x["id"].startswith(prefix):
+                            ojs_id = x["id"].strip(prefix)
+                            print(f'use local_id as ojs_id {ojs_id}')
+                if ojs_id:
+                    id_map[ojs_id] = {"ark": r["id"], "source": r["source"], "doi": r["doi"]}
+                    print(f'add {ojs_id}: {id_map[ojs_id]}')
+
+                ark_map[r["id"]]  = {"source": r["source"], "doi": r["doi"]}
 
         ctype = ContentType.objects.get(app_label='submission', model='article')
 
         for a in j.article_set.all():
+            ark = None
             desc = f'Article {a.pk} imported by Journal Transporter.'
             e = LogEntry.objects.filter(content_type=ctype, object_id=a.pk, description__startswith=desc)
             if e.count() > 1:
@@ -47,25 +77,41 @@ class Command(BaseCommand):
                 print(f'ERROR Article {a.pk}: no log entries found')
             else:
                 d = json.loads(e[0].description.partition("Import metadata:")[2])
+                print(f'found log entry: {d}')
+
 
                 for i in d['external_identifiers']:
+                    # source_id is the ojs id
                     if i['name'] == "source_id":
                         ojs_id = i['value']
+                        print(f'parsed ojs id = {ojs_id}')
+                    # some items also logged an ark upon import
+                    if i['name'] == "ark":
+                        ark = i["value"]
+                        print(f'parsed ark = {ark}')
 
                 if ojs_id in id_map:
-                    ark = f'ark:/13030/{id_map[ojs_id]["ark"]}'
+                    ark = id_map[ojs_id]["ark"]
                     source = id_map[ojs_id]["source"]
+                    doi = id_map[ojs_id]["doi"]
+                elif ark:
+                    source = ark_map[ark]["source"]
+                    doi = ark_map[ark]["doi"]
 
+                print(f'ark = {ark}, ojs_id = {ojs_id}')
+
+                if ark:
+                    ark = f'ark:/13030/{ark}'
                     e, created = EscholArticle.objects.get_or_create(article=a, ark=ark, source_name=source)
                     if created:
                         print(f'Created eschol article {ark}')
                     else:
                         print(f'Got eschol article {ark}')
 
-                    if "doi" in id_map[ojs_id] and not id_map[ojs_id]["doi"] == 'NULL':
+                    if doi and not doi == 'NULL':
                         doi_options = {
                             'id_type': 'doi',
-                            'identifier': id_map[ojs_id]["doi"],
+                            'identifier': doi,
                             'article': a
                         }
 

--- a/test_files/test1.tsv
+++ b/test_files/test1.tsv
@@ -1,0 +1,2 @@
+id	source	external_id	doi	local_ids
+qt00000001	ojs	100	10.00000/C40001	[{"id": "TST_100", "type": null}]

--- a/test_files/test2.tsv
+++ b/test_files/test2.tsv
@@ -1,0 +1,2 @@
+id	source	external_id	doi	local_ids
+qt00000002	bepress	100	10.00000/C40002	[{"id": "TST_100", "type": null}]

--- a/test_files/test3.tsv
+++ b/test_files/test3.tsv
@@ -1,0 +1,2 @@
+id	source	external_id	doi	local_ids
+qt00000003	bepress	101	10.00000/C40003	NULL

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,82 @@
+from io import StringIO
+import os
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from utils.testing import helpers
+from utils.models import LogEntry
+
+from plugins.eschol.models import EscholArticle
+from identifiers.models import Identifier
+
+LOG_ENTRY1 = """Article {} imported by Journal Transporter.
+
+Import metadata:
+{{"imported_at": "2023-03-27 06:56:17.753986", "external_identifiers": [{{"name": "source_id", "value": "100"}}], "journal_transporter_article_uuid": "00000000-0000-0000-0000-000000000000"}}
+"""
+
+LOG_ENTRY2 = """Article {} imported by Journal Transporter.
+
+Import metadata:
+{{"imported_at": "2023-03-27 06:56:17.753986", "external_identifiers": [{{"name": "source_id", "value": "100"}}, {{"name": "ark", "value": "qt00000003"}}], "journal_transporter_article_uuid": "00000000-0000-0000-0000-000000000000"}}
+"""
+
+class TestImportArks(TestCase):
+
+    def setUp(self):
+        self.journal, _ = helpers.create_journals()
+        self.article = helpers.create_article(self.journal)
+
+    def create_log_entry(self, desc):
+        self.log_entry = LogEntry.add_entry([], desc.format(self.article.pk), "info", None, target=self.article, subject="Import")
+        self.log_entry.save()
+
+    def get_file_path(self, filename):
+        return f'{os.path.dirname(__file__)}/test_files/{filename}'
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "add_arks",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def test_match_source_id_to_external_id(self):
+        self.create_log_entry(LOG_ENTRY1)
+        out = self.call_command(self.journal.code, self.get_file_path("test1.tsv"))
+        self.assertEqual(EscholArticle.objects.count(), 1)
+        a = EscholArticle.objects.get(article=self.article)
+        self.assertEqual(a.ark, "ark:/13030/qt00000001")
+        self.assertEqual(a.source_name, "ojs")
+        self.assertEqual(Identifier.objects.count(), 1)
+        i = Identifier.objects.get(article=self.article)
+        self.assertEqual(i.identifier, "10.00000/C40001")
+
+    def test_match_source_id_to_local_id(self):
+        self.create_log_entry(LOG_ENTRY1)
+        out = self.call_command(self.journal.code, self.get_file_path("test2.tsv"))
+        self.assertEqual(EscholArticle.objects.count(), 1)
+        a = EscholArticle.objects.get(article=self.article)
+        self.assertEqual(a.ark, "ark:/13030/qt00000002")
+        self.assertEqual(a.source_name, "bepress")
+        self.assertEqual(Identifier.objects.count(), 1)
+        i = Identifier.objects.get(article=self.article)
+        self.assertEqual(i.identifier, "10.00000/C40002")
+
+    def test_ark_from_log_entry(self):
+        self.create_log_entry(LOG_ENTRY2)
+        out = self.call_command(self.journal.code, self.get_file_path("test3.tsv"))
+        self.assertEqual(EscholArticle.objects.count(), 1)
+        a = EscholArticle.objects.get(article=self.article)
+        self.assertEqual(a.ark, "ark:/13030/qt00000003")
+        self.assertEqual(a.source_name, "bepress")
+        self.assertEqual(Identifier.objects.count(), 1)
+        i = Identifier.objects.get(article=self.article)
+        self.assertEqual(i.identifier, "10.00000/C40003")
+
+


### PR DESCRIPTION
- if source in jschol arks table is not 'ojs' look for a local_id from ojs
- Parse out ark from janeway log entry if it's available. Sometimes these items don't otherwise match
- Test all three possible match scenarios

