### PR TITLE
fix bug in string parsing for local id matching

### DIFF
--- a/management/commands/add_arks.py
+++ b/management/commands/add_arks.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
                         # matches the pattern
                         prefix = f'{journal_code}_'
                         if x["id"].startswith(prefix):
-                            ojs_id = x["id"].strip(prefix)
+                            ojs_id = x["id"][len(prefix):]
                             print(f'use local_id as ojs_id {ojs_id}')
                 if ojs_id:
                     id_map[ojs_id] = {"ark": r["id"], "source": r["source"], "doi": r["doi"]}

--- a/test_files/test4.tsv
+++ b/test_files/test4.tsv
@@ -1,0 +1,2 @@
+id	source	external_id	doi	local_ids
+qt2vm455x0	sync	qt2vm455x0	10.5070/L214356302	[{"id": "uccllt_l2_56302", "type": null}]

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from utils.testing import helpers
 from utils.models import LogEntry
+from journal.models import Journal
 
 from plugins.eschol.models import EscholArticle
 from identifiers.models import Identifier
@@ -21,6 +22,11 @@ LOG_ENTRY2 = """Article {} imported by Journal Transporter.
 Import metadata:
 {{"imported_at": "2023-03-27 06:56:17.753986", "external_identifiers": [{{"name": "source_id", "value": "100"}}, {{"name": "ark", "value": "qt00000003"}}], "journal_transporter_article_uuid": "00000000-0000-0000-0000-000000000000"}}
 """
+
+LOG_ENTRY3 = """Article {} imported by Journal Transporter.
+
+Import metadata:
+{{"imported_at": "2023-09-18 15:05:17.539996", "external_identifiers": [{{"name": "source_id", "value": "56302"}}], "journal_transporter_article_uuid": "70e03163-625e-53aa-9b8e-070abf2d1a63"}}"""
 
 class TestImportArks(TestCase):
 
@@ -90,4 +96,12 @@ class TestImportArks(TestCase):
         i = Identifier.objects.get(article=self.article)
         self.assertEqual(i.identifier, "10.00000/C40001")
 
+    def test_l2(self):
+        l2 = Journal(code="uccllt_l2", domain="testserver2")
+        l2.save()
+        self.article = helpers.create_article(l2)
+        self.create_log_entry(LOG_ENTRY3)
+
+        out = self.call_command(l2.code, self.get_file_path("test4.tsv"))
+        self.assertEqual(EscholArticle.objects.count(), 1)
 


### PR DESCRIPTION
- Fix bug I noticed in L2 import where some ids were getting truncated incorrectly due to the use of strip.  Use a string slice instead.
- Test it.