### PR TITLE
Pubd 1292 dedup escholarticles

### DIFF
--- a/management/commands/add_arks.py
+++ b/management/commands/add_arks.py
@@ -80,8 +80,6 @@ class Command(BaseCommand):
                 print(f'ERROR Article {a.pk}: no log entries found')
             else:
                 d = json.loads(e[0].description.partition("Import metadata:")[2])
-                print(f'found log entry: {d}')
-
 
                 for i in d['external_identifiers']:
                     # source_id is the ojs id
@@ -91,7 +89,6 @@ class Command(BaseCommand):
                     # some items also logged an ark upon import
                     if i['name'] == "ark":
                         ark = i["value"]
-                        print(f'parsed ark = {ark}')
 
                 ojs_item = id_map.get(ojs_id, False)
                 if ojs_item:
@@ -106,21 +103,18 @@ class Command(BaseCommand):
                         source_id = ark_item["external_id"]
                         doi = ark_item["doi"]
 
-                print(f'ark = {ark}, ojs_id = {ojs_id}')
-
                 if ark:
                     ark = f'ark:/13030/{ark}'
-                    e, created = EscholArticle.objects.get_or_create(article=a, ark=ark, source_name=source, source_id=source_id)
-                    if created:
-                        print(f'Created eschol article {ark}')
-                    else:
-                        print(f'Got eschol article {ark}')
+                    e, created = EscholArticle.objects.get_or_create(article=a, ark=ark,
+                                                                     defaults={'source_name': source,
+                                                                               'source_id': source_id})
+                    if not created and (e.source != source or e.source_id != source_id):
+                        print(f'ERROR: {ark} found with different sources {source} and {e.source_name}')
 
                     if doi and not doi == 'NULL':
                         # If we have an DOI delete any existing DOIs
                         # We assume the DOI coming from the jschol export is the most recent
                         if Identifier.objects.filter(article=a, id_type='doi').exists():
-                            print(f'Deleting old DOIs')
                             Identifier.objects.filter(article=a, id_type='doi').delete()
                         doi_options = {
                             'id_type': 'doi',

--- a/management/commands/add_arks.py
+++ b/management/commands/add_arks.py
@@ -105,11 +105,12 @@ class Command(BaseCommand):
 
                 if ark:
                     ark = f'ark:/13030/{ark}'
-                    e, created = EscholArticle.objects.get_or_create(article=a, ark=ark,
-                                                                     defaults={'source_name': source,
+                    e, created = EscholArticle.objects.get_or_create(article=a,
+                                                                     defaults={'ark': ark,
+                                                                               'source_name': source,
                                                                                'source_id': source_id})
-                    if not created and (e.source != source or e.source_id != source_id):
-                        print(f'ERROR: {ark} found with different sources {source} and {e.source_name}')
+                    if not created and (e.ark != ark or e.source != source or e.source_id != source_id):
+                        print(f'ERROR: {e} does not match {ark} | {source} | {source_id}')
 
                     if doi and not doi == 'NULL':
                         # If we have an DOI delete any existing DOIs

--- a/tests/test_eschol_connector.py
+++ b/tests/test_eschol_connector.py
@@ -71,7 +71,7 @@ class EscholConnectorTest(TestCase):
         j, e = get_article_json(self.article, get_unit(self.journal))
 
         self.assertEqual(j['id'], 'ark:/13030/qtXXXXXXXX')
-        self.assertIn(f"http://localhost/TST/plugins/eschol/download/{self.article.pk}/file/", j["contentLink"])
+        self.assertIn(f"http://localhost/TST/plugins/escholarship-publishing-plugin/download/{self.article.pk}/file/", j["contentLink"])
         self.assertEqual(j["contentFileName"], 'qtXXXXXXXX.html')
 
         self.assertEqual(len(j['suppFiles']), 2)
@@ -79,18 +79,18 @@ class EscholConnectorTest(TestCase):
         self.assertEqual(j['suppFiles'][0]['file'], 'qtXXXXXXXX.xml')
         self.assertEqual(j['suppFiles'][0]['contentType'], 'application/xml')
         self.assertEqual(j['suppFiles'][0]['size'], 157291)
-        self.assertIn(f"http://localhost/TST/plugins/eschol/download/{self.article.pk}/file/{xml_obj.pk}/?access=", j['suppFiles'][0]['fetchLink'])
+        self.assertIn(f"http://localhost/TST/plugins/escholarship-publishing-plugin/download/{self.article.pk}/file/{xml_obj.pk}/?access=", j['suppFiles'][0]['fetchLink'])
         self.assertEqual(j['suppFiles'][0]['title'], '[XML] Test Article from Utils Testing Helpers')
 
         self.assertEqual(j['suppFiles'][1]['file'], 'test.pdf')
         self.assertEqual(j['suppFiles'][1]['contentType'], 'application/pdf')
         self.assertEqual(j['suppFiles'][1]['size'], 4)
-        self.assertIn(f"http://localhost/TST/plugins/eschol/download/{self.article.pk}/file/{pdf_obj.pk}/?access=", j['suppFiles'][1]['fetchLink'])
+        self.assertIn(f"http://localhost/TST/plugins/escholarship-publishing-plugin/download/{self.article.pk}/file/{pdf_obj.pk}/?access=", j['suppFiles'][1]['fetchLink'])
         #self.assertEqual(j['suppFiles'][1]['title'], '')
 
         self.assertEqual(len(j['imgFiles']), 1)
         self.assertEqual(j['imgFiles'][0]['file'], 'test.png')
-        self.assertIn(f"http://localhost/TST/plugins/eschol/download/{self.article.pk}/file/{img_obj.pk}/?access=", j['imgFiles'][0]['fetchLink'])
+        self.assertIn(f"http://localhost/TST/plugins/escholarship-publishing-plugin/download/{self.article.pk}/file/{img_obj.pk}/?access=", j['imgFiles'][0]['fetchLink'])
 
     def test_galley(self):
 
@@ -99,7 +99,7 @@ class EscholConnectorTest(TestCase):
 
         j, e = get_article_json(self.article, get_unit(self.journal))
 
-        self.assertIn(f"http://localhost/TST/plugins/eschol/download/{self.article.pk}/file/{f.pk}/?access=", j["contentLink"])
+        self.assertIn(f"http://localhost/TST/plugins/escholarship-publishing-plugin/download/{self.article.pk}/file/{f.pk}/?access=", j["contentLink"])
         self.assertEqual(j["contentFileName"], "test.pdf")
 
     def test_supp_files(self):
@@ -134,12 +134,12 @@ class EscholConnectorTest(TestCase):
         self.assertEqual(j['suppFiles'][0]['file'], 'test.pdf')
         self.assertEqual(j['suppFiles'][0]['contentType'], 'application/pdf')
         self.assertEqual(j['suppFiles'][0]['size'], 4)
-        self.assertIn(f"http://localhost/TST/plugins/eschol/download/{self.article.pk}/file/{tf1.pk}/?access=", j['suppFiles'][0]['fetchLink'])
+        self.assertIn(f"http://localhost/TST/plugins/escholarship-publishing-plugin/download/{self.article.pk}/file/{tf1.pk}/?access=", j['suppFiles'][0]['fetchLink'])
 
         self.assertEqual(j['suppFiles'][1]['file'], 'test.xml')
         self.assertEqual(j['suppFiles'][1]['contentType'], 'application/xml')
         self.assertEqual(j['suppFiles'][1]['size'], 250)
-        self.assertIn(f"http://localhost/TST/plugins/eschol/download/{self.article.pk}/file/{tf2.pk}/?access=", j['suppFiles'][1]['fetchLink'])
+        self.assertIn(f"http://localhost/TST/plugins/escholarship-publishing-plugin/download/{self.article.pk}/file/{tf2.pk}/?access=", j['suppFiles'][1]['fetchLink'])
 
 
     def test_invalid_license(self):

--- a/tests/test_import_arks.py
+++ b/tests/test_import_arks.py
@@ -107,3 +107,12 @@ class TestImportArks(TestCase):
         out = self.call_command(l2.code, self.get_file_path("test4.tsv"))
         self.assertEqual(EscholArticle.objects.count(), 1)
 
+    def test_existing_escholarticle(self):
+        e = EscholArticle.objects.create(article=self.article, ark='ark:/13030/qt00000002', source_name='ojs', source_id="999")
+        self.create_log_entry(LOG_ENTRY1)
+        out = self.call_command(self.journal.code, self.get_file_path("test1.tsv"))
+        self.assertEqual(EscholArticle.objects.count(), 1)
+        a = EscholArticle.objects.get(article=self.article)
+        self.assertEqual(a.ark, "ark:/13030/qt00000002")
+        self.assertEqual(a.source_name, "ojs")
+        self.assertEqual(a.source_id, "999")


### PR DESCRIPTION
- Make sure that only one eschol article object is created per article. I'm not sure exactly the situation when this was happening but before this change if an article got mapped to multiple arks or the same ark with a different source two would have been created.