### PR TITLE
Fix error handling

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -214,7 +214,7 @@ def get_article_json(article, unit):
         "published": article.date_published.strftime("%Y-%m-%d"), # required
         "isPeerReviewed": article.peer_reviewed, # required
         "contentVersion": "PUBLISHER_VERSION",
-        "journal": article.journal.name,
+        "journal": str(article.journal.name), # cast as str here, forces db to resolve
         "units": [unit], # required
         "pubRelation": "EXTERNAL_PUB"
     }

--- a/logic.py
+++ b/logic.py
@@ -82,7 +82,7 @@ def send_to_eschol(query, variables):
                       params=params,
                       json={'query': query, 'variables': variables},
                       headers=headers,
-                      timeout=(5, 10))
+                      timeout=(20, 30))
     if "Mysql2::Error: Deadlock" in r.text:
         time.sleep(5)
         send_to_eschol(query, variables)


### PR DESCRIPTION
- Rearrange error handling so if we get an unexpected error from send it doesn't abort the entire issue send
- Fix bug where some unexpected errors were causing multiple issue publication histories to be created (and leaving an incomplete one)
- Make sure journal title is resolved to a string when added to the json.  In async processing it was sometimes trying to serialize some unresolved db object
- Increase the timeouts for interacting with the API. It's slow sometimes.