### PR TITLE
Issue publication timeout

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -17,6 +17,7 @@ class ArticlePublicationHistoryAdmin(admin.ModelAdmin):
 
 class IssuePublicationHistoryAdmin(admin.ModelAdmin):
     raw_id_fields = ('issue',)
+    list_filter = ('success', 'is_complete',)
 
 admin.site.register(JournalUnit, JournalUnitAdmin)
 admin.site.register(EscholArticle, EscholArticleAdmin)

--- a/logic.py
+++ b/logic.py
@@ -92,7 +92,7 @@ def send_to_eschol(query, variables, sleep=10):
             logger.info("Encountered eScholarship deadlock retrying...")
             time.sleep(sleep)
             # If we're repeatedly getting deadlock errors increase the sleep time
-            r = send_to_eschol(query, variables, sleep=(sleep * 2))
+            r = send_to_eschol(query, variables, sleep=sleep * 2)
         else:
             logger.error(f"Deadlock sleep max reached: {variables}")
     return r

--- a/logic.py
+++ b/logic.py
@@ -84,7 +84,7 @@ def send_to_eschol(query, variables):
                       headers=headers,
                       timeout=(20, 30))
     if "Mysql2::Error: Deadlock" in r.text:
-        logger.info(f"Encountered eScholarship deadlock retrying...")
+        logger.info("Encountered eScholarship deadlock retrying...")
         time.sleep(10)
         r = send_to_eschol(query, variables)
     return r

--- a/logic.py
+++ b/logic.py
@@ -84,8 +84,9 @@ def send_to_eschol(query, variables):
                       headers=headers,
                       timeout=(20, 30))
     if "Mysql2::Error: Deadlock" in r.text:
-        time.sleep(5)
-        send_to_eschol(query, variables)
+        logger.info(f"Encountered eScholarship deadlock retrying...")
+        time.sleep(10)
+        r = send_to_eschol(query, variables)
     return r
 
 def get_provisional_id(article):

--- a/logic.py
+++ b/logic.py
@@ -74,19 +74,27 @@ def save_article_file(output, article, original_filename, kwargs=None):
 
     return new_file
 
-def send_to_eschol(query, variables):
+def send_to_eschol(query, variables, sleep=10):
     url = settings.ESCHOL_API_URL
     params = {'access': settings.ESCHOL_ACCESS_TOKEN}
     headers = {"Privileged": settings.ESCHOL_PRIV_KEY}
     r = requests.post(url,
-                      params=params,
-                      json={'query': query, 'variables': variables},
-                      headers=headers,
-                      timeout=(20, 30))
+                     params=params,
+                     json={'query': query, 'variables': variables},
+                     headers=headers,
+                     timeout=(20, 30))
+    # Sometimes submit throws a deadlock error that comes back in the
+    # API text response (rather than as an error code or a proper json error message)
+    # Once we move off of submit-style backend for the API we should be able
+    # to remove this special case
     if "Mysql2::Error: Deadlock" in r.text:
-        logger.info("Encountered eScholarship deadlock retrying...")
-        time.sleep(10)
-        r = send_to_eschol(query, variables)
+        if sleep < getattr(settings, "ESCHOL_SLEEP_MAX", 100):
+            logger.info("Encountered eScholarship deadlock retrying...")
+            time.sleep(sleep)
+            # If we're repeatedly getting deadlock errors increase the sleep time
+            r = send_to_eschol(query, variables, sleep=(sleep * 2))
+        else:
+            logger.error(f"Deadlock sleep max reached: {variables}")
     return r
 
 def get_provisional_id(article):

--- a/tests/test_eschol_connector.py
+++ b/tests/test_eschol_connector.py
@@ -460,6 +460,26 @@ class EscholConnectorTest(TestCase):
         apub = logic.article_to_eschol(article=self.article)
         self.assertTrue(apub.success)
 
+    @override_settings(
+        ESCHOL_API_URL="test",
+        ESCHOL_ACCESS_TOKEN="testtest",
+        ESCHOL_PRIV_KEY="key",
+        JSCHOL_URL="test.test/",
+        ESCHOL_SLEEP_MAX=20
+    )
+    @mock.patch('plugins.eschol.logic.requests.post')
+    def test_eschol_deadlock(self, mock_send):
+        issue = helpers.create_issue(self.journal, articles=[self.article])
+        self.article.primary_issue = issue
+        self.article.issues.add(issue)
+        self.article.save()
+
+        mock_send.return_value = Response("Mysql2::Error: Deadlock")
+
+        apub = logic.article_to_eschol(article=self.article)
+        assert mock_send.call_count == 2
+        self.assertFalse(apub.success)
+
     @mock.patch('plugins.eschol.logic.send_to_eschol')
     def test_issue_meta_with_cover(self, mock_send):
         issue = helpers.create_issue(self.journal, articles=[self.article])

--- a/views.py
+++ b/views.py
@@ -20,7 +20,11 @@ from .plugin_settings import PLUGIN_NAME
 def publish_issue_task(issue_id):
     issue = Issue.objects.get(pk=issue_id)
 
-    timeout = datetime.now() - timedelta(seconds=settings.DJANGO_Q["retry"])
+    # Mark complete and unsuccessful any issue publication
+    # attempts that have timed out
+    q_settings = getattr(settings, 'DJANGO_Q', {})
+    delta = timedelta(seconds=(q_settings.get("retry", 400)))
+    timeout = datetime.now() - delta
     objs = IssuePublicationHistory.objects.filter(
         issue=issue,
         is_complete=False,

--- a/views.py
+++ b/views.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseForbidden
 from django.contrib.auth.decorators import login_required
+from django.conf import settings
 
 from django_q.tasks import async_task
 
@@ -18,6 +19,13 @@ from .plugin_settings import PLUGIN_NAME
 
 def publish_issue_task(issue_id):
     issue = Issue.objects.get(pk=issue_id)
+
+    timeout = datetime.now() - timedelta(seconds=settings.DJANGO_Q["retry"])
+    for h in IssuePublicationHistory.objects.filter(issue=issue, is_complete=False, date__lt=timeout):
+        h.is_complete = True
+        h.success = False
+        h.save()
+
     if not IssuePublicationHistory.objects.filter(issue=issue, is_complete=False).exists():
         ipub = issue_to_eschol(issue=issue)
         return str(ipub)

--- a/views.py
+++ b/views.py
@@ -21,7 +21,12 @@ def publish_issue_task(issue_id):
     issue = Issue.objects.get(pk=issue_id)
 
     timeout = datetime.now() - timedelta(seconds=settings.DJANGO_Q["retry"])
-    for h in IssuePublicationHistory.objects.filter(issue=issue, is_complete=False, date__lt=timeout):
+    objs = IssuePublicationHistory.objects.filter(
+        issue=issue,
+        is_complete=False,
+        date__lt=timeout
+    )
+    for h in objs:
         h.is_complete = True
         h.success = False
         h.save()

--- a/views.py
+++ b/views.py
@@ -23,7 +23,7 @@ def publish_issue_task(issue_id):
     # Mark complete and unsuccessful any issue publication
     # attempts that have timed out
     q_settings = getattr(settings, 'DJANGO_Q', {})
-    delta = timedelta(seconds=(q_settings.get("retry", 400)))
+    delta = timedelta(seconds=q_settings.get("retry", 400))
     timeout = datetime.now() - delta
     objs = IssuePublicationHistory.objects.filter(
         issue=issue,


### PR DESCRIPTION
- Add is_complete and success filters to issue publication admin for easier debugging
- Log invocation of deadlock error on submit (so we can verify this is what's happening)
- Increase sleep time if multiple retries are necessary up to a max time then give up
- Fix bug where return value was lost
- Before attempting to publish an issue close out any expired issue publication histories